### PR TITLE
feat(pages/repos): sort models in a repo desc so newest is at the top

### DIFF
--- a/app/pages/repos/_repo_id/index/get.rs
+++ b/app/pages/repos/_repo_id/index/get.rs
@@ -40,7 +40,7 @@ pub async fn get(
 				models.created_at
 			from models
 			where models.repo_id = $1
-			order by models.created_at
+			order by models.created_at desc
 		",
 	)
 	.bind(&repo_id.to_string())


### PR DESCRIPTION
You don't have to accept this but if I keep uploading more and more models I'd personally want to always see the newest one on the top of the page since generally the newest model is the one I care about. I clicked on the top one and was surprised the accuracy was lower than I thought because I just assumed the newest was on top.

Also, just wanted to be first for a PR :) 